### PR TITLE
Prevent reshape in resizing

### DIFF
--- a/aispace2/jupyter/stepdomwidget.py
+++ b/aispace2/jupyter/stepdomwidget.py
@@ -2,7 +2,7 @@ import threading
 from time import sleep
 
 from ipywidgets import DOMWidget
-from traitlets import Float, validate
+from traitlets import Float, Integer, validate
 
 
 class ReturnableThread(threading.Thread):
@@ -34,9 +34,12 @@ class StepDOMWidget(DOMWidget):
     Attributes:
         sleep_time (float): The time delay between consecutive display calls.
         line_width (float): The width of the edges in the visualization.
+        text_size (int):    The size of the text inside the node
     """
 
     line_width = Float(4.0).tag(sync=True)
+    text_size = Integer(10).tag(sync=True)
+
 
     def __init__(self):
         super().__init__()
@@ -72,6 +75,12 @@ class StepDOMWidget(DOMWidget):
         """Cap line_width at a minimum value."""
         line_width = proposal['value']
         return min(1, line_width)
+
+    @validate("text_size")
+    def _validate_line_width(self, proposal):
+        """Cap line_width at a minimum value."""
+        text_size = proposal['value']
+        return max(5, text_size)
 
     def _initialize_controls(self):
         """Sets up functions that can be used to control the visualization."""

--- a/js/src/GraphLayout.ts
+++ b/js/src/GraphLayout.ts
@@ -277,7 +277,7 @@ export function relativeLayout() {
         minY = Math.min(node.y, minY);
       }
 
-      const edgePadding = 30;
+      const edgePadding = 60;
 
       for (const node of graph.nodes) {
         // Scale node positions to fit new width/height, plus some edge padding

--- a/js/src/components/RectangleGraphNode.vue
+++ b/js/src/components/RectangleGraphNode.vue
@@ -1,8 +1,8 @@
 <template>
   <g>
     <rect :width="width" :height="height" :x="-width / 2" :y="-height / 2" :fill="fill" :stroke="stroke" :stroke-width="strokeWidth"></rect>
-    <text ref="text" x="0" :y="0" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
-      {{truncatedText}}
+    <text ref="text" x="0" :y="0" :fill="textColour" text-anchor="middle" :font-size="textSize" alignment-baseline="middle">
+      {{displayText}}
     </text>
     <title>{{text}}</title>
   </g>
@@ -35,6 +35,9 @@ export default class RectangleGraphNode extends Vue {
   /** The colour of the text inside the node. */
   @Prop({ default: "black" })
   textColour: string;
+  // The size of the text inside the node
+  @Prop({default: 15}) textSize: number;
+  @Prop({default: false}) hover: boolean;
 
   /** The maximum width of the text, in pixels, before truncation occurs. */
   maxWidth = 90;
@@ -57,12 +60,21 @@ export default class RectangleGraphNode extends Vue {
 
   /** Width of the rectangle. */
   get width() {
-    return Math.min(Math.max(this.textWidth, 50), this.maxWidth) + 10;
+    this.computeWidthAndHeight();
+    if (this.hover){
+      return this.textWidth;
+    } else {
+      return Math.min(Math.max(this.textWidth, 50), this.maxWidth) + 10;
+    }
   }
 
   /** Height of the rectangle. */
   get height() {
     return Math.min(Math.max(this.textHeight, 30), 45) + 5;
+  }
+
+  get displayText() {
+    return this.hover ? this.text : this.truncatedText;
   }
 
   /**
@@ -79,7 +91,7 @@ export default class RectangleGraphNode extends Vue {
         : 0;
     this.textWidth =
       this.$refs.text != null
-        ? this.$refs.text.getBoundingClientRect().width
+        ? this.measureText(this.text)
         : 0;
   }
 
@@ -115,6 +127,14 @@ export default class RectangleGraphNode extends Vue {
         this._truncateText();
       }
     });
+  }
+
+  // measure text width in pixels
+  measureText(text) {
+    let canvas = document.createElement('canvas');
+    let context = canvas.getContext("2d");
+    context.font = this.textSize.toString() + "pt serif";
+    return context.measureText(text).width;
   }
 
   @Watch("text")

--- a/js/src/csp/CSPVisualizer.ts
+++ b/js/src/csp/CSPVisualizer.ts
@@ -4,7 +4,7 @@ import { debounce } from "underscore";
 import Vue from "vue";
 import * as Analytics from "../Analytics";
 import { Graph, ICSPGraphNode, IGraphEdge } from "../Graph";
-import { d3ForceLayout, GraphLayout } from "../GraphLayout";
+import { d3ForceLayout, GraphLayout, relativeLayout } from "../GraphLayout";
 import * as StepEvents from "../StepEvents";
 import CSPGraphVisualizer from "./components/CSPVisualizer.vue";
 import * as CSPEvents from "./CSPVisualizerEvents";
@@ -45,12 +45,12 @@ export default class CSPViewer extends widgets.DOMWidgetView {
     });
   }
 
-  public render() {
+  public   render() {
     timeout(() => {
       this.vue = new CSPGraphVisualizer({
         data: {
           graph: this.model.graph,
-          layout: new GraphLayout(d3ForceLayout()),
+          layout: new GraphLayout(d3ForceLayout(), relativeLayout()),
           width: 0,
           height: 0,
           output: null,

--- a/js/src/csp/CSPVisualizer.ts
+++ b/js/src/csp/CSPVisualizer.ts
@@ -53,7 +53,8 @@ export default class CSPViewer extends widgets.DOMWidgetView {
           layout: new GraphLayout(d3ForceLayout()),
           width: 0,
           height: 0,
-          output: null
+          output: null,
+          textSize: this.model.textSize
         }
       }).$mount(this.el);
 

--- a/js/src/csp/CSPVisualizerModel.ts
+++ b/js/src/csp/CSPVisualizerModel.ts
@@ -61,6 +61,11 @@ export default class CSPViewerModel extends widgets.DOMWidgetModel {
     return this.get("line_width");
   }
 
+  // The size of the text inside the node
+  get textSize(): number {
+    return this.get("text_size");
+  }
+
   /** The Graph representing the CSP problem. */
   get graph(): Graph {
     return this.get("graph");

--- a/js/src/csp/components/CSPVisualizer.vue
+++ b/js/src/csp/components/CSPVisualizer.vue
@@ -3,13 +3,15 @@
     <GraphVisualizerBase :graph="graph" @click:node="nodeClicked" @click:edge="edgeClicked" :layout="layout" :transitions="true">
       <template slot="node" scope="props">
         <EllipseGraphNode v-if="props.node.type === 'csp:variable'" :text="props.node.name"
-                         :subtext="domainText(props.node)" 
+                         :subtext="domainText(props.node)" :textSize="textSize"
                          :stroke="nodeStrokeColour(props.node, props.hover)" :stroke-width="nodeStrokeWidth(props.node)"
-                         :textColour="props.hover ? 'white' : 'black'" :fill="props.hover ? 'black' : 'white'">
+                         :textColour="props.hover ? 'white' : 'black'" :fill="props.hover ? 'black' : 'white'"
+                          :hover="props.hover">
         </EllipseGraphNode>
-        <RectangleGraphNode v-if="props.node.type === 'csp:constraint'" :text="constraintText(props.node)"
+        <RectangleGraphNode v-if="props.node.type === 'csp:constraint'" :text="constraintText(props.node)" :text-size="textSize"
                            :stroke="nodeStrokeColour(props.node, props.hover)" :stroke-width="nodeStrokeWidth(props.node)"
-                           :textColour="props.hover ? 'white' : 'black'" :fill="props.hover ? 'black' : 'white'">
+                           :textColour="props.hover ? 'white' : 'black'" :fill="props.hover ? 'black' : 'white'"
+                            :hover="props.hover">
         </RectangleGraphNode>
       </template>
       <template slot="edge" scope="props">
@@ -68,6 +70,8 @@ export default class CSPGraphInteractor extends Vue {
   output: string;
   /** Layout object that controls where nodes are drawn. */
   layout: GraphLayout;
+  // The size of the text inside the node
+  textSize: number;
 
   edgeClicked(edge: IGraphEdge) {
     this.$emit("click:edge", edge);

--- a/notebooks/csp/arc_consistency.ipynb
+++ b/notebooks/csp/arc_consistency.ipynb
@@ -39,10 +39,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "code_folding": [],
-    "collapsed": true,
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
@@ -203,9 +202,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
-    "collapsed": true,
     "extensions": {
      "jupyter_dashboards": {
       "version": 1,
@@ -225,7 +223,37 @@
     },
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c8dd775224dd48b08393aa73dcd894ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>Con_solver</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "Con_solver(graph=CSP({'one_across': {'big', 'bus', 'has', 'car', 'ant'}, 'one_down': {'lane', 'buys', 'book', 'year', 'hold'}, 'two_down': {'search', 'ginger', 'symbol', 'syntax'}, 'three_across': {'land', 'buys', 'book', 'year', 'hold'}, 'four_across': {'big', 'bus', 'has', 'car', 'ant'}}, [\"meet_at(0,0)('one_across', 'one_down')\", \"meet_at(2,0)('one_across', 'two_down')\", \"meet_at(2,2)('three_across', 'two_down')\", \"meet_at(0,2)('three_across', 'one_down')\", \"meet_at(0,4)('four_across', 'two_down')\"]), line_width=15.0, text_size=12)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from aipython.cspExamples import simple_csp1, simple_csp2, extended_csp, crossword1, crossword2, crossword2d\n",
     "from IPython.display import display\n",
@@ -233,14 +261,22 @@
     "con_solver = Con_solver(crossword1)\n",
     "\n",
     "# Visualization options\n",
-    "con_solver.visualizer.line_width = 10\n",
+    "con_solver.visualizer.line_width = 15\n",
     "con_solver.visualizer.sleep_time = 0.1\n",
+    "con_solver.visualizer.text_size = 12\n",
     "\n",
     "display(con_solver)\n",
     "\n",
     "# Call the function to execute in our visualization\n",
     "con_solver.solve_one()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -268,18 +304,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Graphs in CSP resize whenever we resize the canvas size. This is an issue because it makes it more difficult for users to find the nodes due to their positions may have been changed drastically after each canvas size change.
    
Relative layout has been applied to prevent the graph from drastically reshape and reposition its nodes after canvas resize. However, due to the new feature of hovering to display full node content, the padding set in relative layout is not sufficient to include all nodes fully in the canvas. So the padding is increased from 30 to 60, where 50 is the maximum size of unhovered node and an additional 10 for a comfortable zone in case of user setting super large font size.