### PR TITLE
Graphs in CSP resize whenever we resize the canvas size. This is an i…

### DIFF
--- a/js/src/GraphLayout.ts
+++ b/js/src/GraphLayout.ts
@@ -277,7 +277,7 @@ export function relativeLayout() {
         minY = Math.min(node.y, minY);
       }
 
-      const edgePadding = 30;
+      const edgePadding = 60;
 
       for (const node of graph.nodes) {
         // Scale node positions to fit new width/height, plus some edge padding

--- a/js/src/csp/CSPVisualizer.ts
+++ b/js/src/csp/CSPVisualizer.ts
@@ -4,7 +4,7 @@ import { debounce } from "underscore";
 import Vue from "vue";
 import * as Analytics from "../Analytics";
 import { Graph, ICSPGraphNode, IGraphEdge } from "../Graph";
-import { d3ForceLayout, GraphLayout } from "../GraphLayout";
+import { d3ForceLayout, GraphLayout, relativeLayout } from "../GraphLayout";
 import * as StepEvents from "../StepEvents";
 import CSPGraphVisualizer from "./components/CSPVisualizer.vue";
 import * as CSPEvents from "./CSPVisualizerEvents";
@@ -45,12 +45,12 @@ export default class CSPViewer extends widgets.DOMWidgetView {
     });
   }
 
-  public render() {
+  public   render() {
     timeout(() => {
       this.vue = new CSPGraphVisualizer({
         data: {
           graph: this.model.graph,
-          layout: new GraphLayout(d3ForceLayout()),
+          layout: new GraphLayout(d3ForceLayout(), relativeLayout()),
           width: 0,
           height: 0,
           output: null


### PR DESCRIPTION
…ssue because it makes it more difficult for users to find the nodes due to their positions may have been changed drastically after each canvas size change.

Relative layout has been applied to prevent the graph from drastically reshape and reposition its nodes after canvas resize. However, due to the new feature of hovering to display full node content, the padding set in relative layout is not sufficient to include all nodes fully in the canvas. So the padding is increased from 30 to 60, where 50 is the maximum size of unhovered node and an additional 10 for a comfortable zone in case of user setting super large font size.