### PR TITLE
Toggle to zoom

### DIFF
--- a/js/src/components/RectangleGraphNode.vue
+++ b/js/src/components/RectangleGraphNode.vue
@@ -1,5 +1,5 @@
 <template>
-  <g>
+  <g @click="isExpanded = !isExpanded">
     <rect :width="size.width" :height="size.height" :x="-size.width / 2" :y="-size.height / 2" :fill="fill" :stroke="stroke" :stroke-width="strokeWidth"></rect>
     <text ref="text" x="0" :y="0" :fill="textColour" text-anchor="middle" :font-size="textSize" alignment-baseline="middle">
       {{displayText}}
@@ -49,6 +49,9 @@ export default class RectangleGraphNode extends Vue {
   minTextWidth = 50;
   // Additional truncate length so there is white padding within a graph node
   padding = 20;
+  // Expansion toggle flag
+  isExpanded = false;
+
   $refs: {
     /** A reference to the primary text element where the text is drawn. */
     text: SVGTextElement;
@@ -66,13 +69,13 @@ export default class RectangleGraphNode extends Vue {
     return bounds;
   }
   get displayText() {
-    let text = this.hover ? this.text : this.truncatedText;
+    let text = (this.hover || this.isExpanded) ? this.text : this.truncatedText;
     return this.format(text);
   }
   /** Width of the rectangle. */
   width() {
     this.computeWidthAndHeight();
-    if (this.hover){
+    if (this.hover || this.isExpanded){
       return this.textWidth;
     } else {
       return Math.min(Math.max(this.textWidth, 50), this.maxWidth);

--- a/js/src/components/RoundedRectangleGraphNode.vue
+++ b/js/src/components/RoundedRectangleGraphNode.vue
@@ -1,8 +1,8 @@
 <template>
-  <g>
+  <g @click="isExpanded = !isExpanded">
       <rect :width="size.width" :height="size.height"
             :x="-size.width/2" :y="-size.height/2"
-            :fill="fill" :stroke="stroke" :stroke-width="strokeWidth" :rx="hover ? 30 : 25"></rect>
+            :fill="fill" :stroke="stroke" :stroke-width="strokeWidth" :rx="(hover || isExpanded) ? 30 : 25"></rect>
 
       <text id="text" :font-size="textSize" ref="text" x="0" :y="subtext != null ? -8 : 0" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
       {{displayText}}
@@ -59,13 +59,13 @@ export default class RoundedRectangleGraphNode extends RectangleGraphNode {
     return Math.max(this.computedTextWidth, this.computedSubtextWidth);
   }
   get displaySubText() {
-    let text = this.hover ? this.subtext : this.truncatedSubtext;
+    let text = (this.hover || this.isExpanded) ? this.subtext : this.truncatedSubtext;
     return this.format(text);
   }
   /* Width of the rounded rectangle */
   width() {
     this.computeWidthAndHeight();
-    if (this.hover) {
+    if (this.hover || this.isExpanded) {
       return this.computedTotalWidth;
     } else {
       return Math.min(Math.max(this.computedTotalWidth, this.minTextWidth), this.maxWidth);


### PR DESCRIPTION
Click on a graph node to expand it. If it is already expanded, the click will revert it back to its unexpanded state / size.