### PR TITLE
Toggle for name

### DIFF
--- a/aispace2/jupyter/stepdomwidget.py
+++ b/aispace2/jupyter/stepdomwidget.py
@@ -2,7 +2,7 @@ import threading
 from time import sleep
 
 from ipywidgets import DOMWidget
-from traitlets import Float, Integer, validate
+from traitlets import Float, Integer, validate, Bool
 
 
 class ReturnableThread(threading.Thread):
@@ -35,11 +35,14 @@ class StepDOMWidget(DOMWidget):
         sleep_time (float): The time delay between consecutive display calls.
         line_width (float): The width of the edges in the visualization.
         text_size (int):    The size of the text inside the node
+        short_name (bool):  True if we want the child nodes to not include parent's common text
+                            Warning: this only removes child's common text if it perfectly matches its parent's
+                            entire text in the same order
     """
 
     line_width = Float(4.0).tag(sync=True)
     text_size = Integer(10).tag(sync=True)
-
+    short_name = Bool(False).tag(sync=True)
 
     def __init__(self):
         super().__init__()

--- a/js/src/search/SearchVisualizer.ts
+++ b/js/src/search/SearchVisualizer.ts
@@ -43,7 +43,7 @@ export default class SearchViewer extends widgets.DOMWidgetView {
     this.listenTo(this.model, "change:graph", () => {
       // Nodes/edges have been added to the graph from the backend.
       this.model.graph.mergeStylesFrom(this.model.previous("graph"));
-      this.vue.graph = this.getGraph();
+      this.vue.graph = this.model.shortName ? this.trimGraph() : this.model.graph;
     });
   }
 
@@ -152,11 +152,8 @@ export default class SearchViewer extends widgets.DOMWidgetView {
     }
   }
 
-  private getGraph() {
+  private trimGraph() {
     let graph = this.model.graph;
-
-    if (this.model.shorterName){
-
     // make backup text of parent
     // child and parent have to be defined since it is connected by an edge
     for (let edge of graph.edges) {
@@ -170,8 +167,7 @@ export default class SearchViewer extends widgets.DOMWidgetView {
       let parent = graph.nodes.find(node => node.id === edge.source.id);
       let childText = this.format(child!.name);
       let parentText = this.format(parent!.name);
-      child!.name = childText.replace(child.parent + ", ", '');
-      }
+      child!.name = childText.replace(child!.parentText + ", ", '');
     }
 
     return graph;

--- a/js/src/search/SearchVisualizer.ts
+++ b/js/src/search/SearchVisualizer.ts
@@ -155,6 +155,8 @@ export default class SearchViewer extends widgets.DOMWidgetView {
   private getGraph() {
     let graph = this.model.graph;
 
+    if (this.model.shorterName){
+
     // make backup text of parent
     // child and parent have to be defined since it is connected by an edge
     for (let edge of graph.edges) {
@@ -170,6 +172,8 @@ export default class SearchViewer extends widgets.DOMWidgetView {
       let parentText = this.format(parent!.name);
       child!.name = childText.replace(child.parent + ", ", '');
       }
+    }
+
     return graph;
   }
 

--- a/js/src/search/SearchVisualizerModel.ts
+++ b/js/src/search/SearchVisualizerModel.ts
@@ -81,6 +81,11 @@ export default class SearchViewerModel extends widgets.DOMWidgetModel {
     this.set("graph", val);
   }
 
+  // True if we want the child node to not include the text of its parent
+  get shorterName(): boolean {
+    return this.get("shorter_name");
+  }
+
   /** True if the visualization should show edge costs. */
   get showEdgeCosts(): boolean {
     return this.get("show_edge_costs");

--- a/js/src/search/SearchVisualizerModel.ts
+++ b/js/src/search/SearchVisualizerModel.ts
@@ -82,8 +82,8 @@ export default class SearchViewerModel extends widgets.DOMWidgetModel {
   }
 
   // True if we want the child node to not include the text of its parent
-  get shorterName(): boolean {
-    return this.get("shorter_name");
+  get shortName(): boolean {
+    return this.get("short_name");
   }
 
   /** True if the visualization should show edge costs. */


### PR DESCRIPTION
Programmatically toggle on boolean short_name for solving_csp_with_search and any other search graphs to hide/unhide parent's text on child's text.

Example:
Parent text: a,b
Child Text: a,b,c

Then this will convert this diagram to:
Parent text: a,b
Child Text: c