### PR TITLE
fix redrawn nodes at original position

### DIFF
--- a/js/src/GraphLayout.ts
+++ b/js/src/GraphLayout.ts
@@ -132,7 +132,7 @@ export function d3ForceLayout(): LayoutFunction {
         });
       }
 
-      scaleNodePositions(layoutParams, graph.nodes);
+      // scaleNodePositions(layoutParams, graph.nodes);
       // Copy over x and y positions onto original graph once simulation is finished
       // if the node did not already have an x, y position
       graphCopy.nodes.forEach((node, i) => {

--- a/js/src/components/GraphVisualizerBase.vue
+++ b/js/src/components/GraphVisualizerBase.vue
@@ -82,6 +82,7 @@
     /** The graph to render. */
     @Prop({ type: Object })
     graph: Graph;
+    prevgraph: Graph;
     /** If true, animates positional changes and other properties of the nodes/edges in this graph. */
     @Prop({ default: false })
     transitions: boolean;
@@ -118,6 +119,7 @@
 
     created() {
       this.graph = this.graph;
+      this.prevgraph = this.graph;
       this.handleResize = debounce(this.handleResize, 300);
     }
 
@@ -329,6 +331,10 @@
     @Watch("graph")
     onGraphChanged(newVal: Graph) {
       // Whenever nodes or edges are added, re-layout the graph
+      // Merge the styles of the previous graph to current graph
+      // Update previous graph
+      this.graph.mergeStylesFrom(this.prevgraph);
+      this.prevgraph = this.graph;
       this.layout.relayout(this.graph, {
         width: this.width,
         height: this.height


### PR DESCRIPTION
Fixed issue #46 .
In the previous version, in forward_planning notebook, while new nodes are added to the graph, the layout assign all nodes with different positions.
In this version, nodes which have been rendered in the previous step are now fixed at their original positions.