### PR TITLE
Csp builder fix

### DIFF
--- a/aispace2/jupyter/csp/cspbuilder.py
+++ b/aispace2/jupyter/csp/cspbuilder.py
@@ -45,7 +45,9 @@ class CSPBuilder(DOMWidget):
 
     def py_code(self):
         """Converts the CSP represented by this builder into Python code."""
-        self.send({
-            'action': 'python-code',
-            'code': csp_to_python_code(self.csp())
-        })
+        return print(csp_to_python_code(self.csp()))
+#         The following code works only in notebook.
+#         self.send({
+#             'action': 'python-code',
+#             'code': csp_to_python_code(self.csp())
+#         })

--- a/aispace2/jupyter/csp/cspbuilder.py
+++ b/aispace2/jupyter/csp/cspbuilder.py
@@ -45,7 +45,7 @@ class CSPBuilder(DOMWidget):
 
     def py_code(self):
         """Converts the CSP represented by this builder into Python code."""
-         self.send({
-             'action': 'python-code',
-             'code': csp_to_python_code(self.csp())
-         })
+        self.send({
+            'action': 'python-code',
+            'code': csp_to_python_code(self.csp())
+        })

--- a/aispace2/jupyter/csp/cspbuilder.py
+++ b/aispace2/jupyter/csp/cspbuilder.py
@@ -45,9 +45,7 @@ class CSPBuilder(DOMWidget):
 
     def py_code(self):
         """Converts the CSP represented by this builder into Python code."""
-        return print(csp_to_python_code(self.csp()))
-#         The following code works only in notebook.
-#         self.send({
-#             'action': 'python-code',
-#             'code': csp_to_python_code(self.csp())
-#         })
+         self.send({
+             'action': 'python-code',
+             'code': csp_to_python_code(self.csp())
+         })

--- a/js/src/csp/components/CSPBuilder.vue
+++ b/js/src/csp/components/CSPBuilder.vue
@@ -120,7 +120,7 @@ export default class CSPGraphBuilder extends Vue {
     if (this.mode === "variable") {
       this.graph.addNode({
         id: shortid.generate(),
-        name: "asdf",
+        name: "Variable",
         x,
         y,
         type: "csp:variable",
@@ -129,7 +129,7 @@ export default class CSPGraphBuilder extends Vue {
     } else if (this.mode === "constraint") {
       this.graph.addNode({
         id: shortid.generate(),
-        name: "asdf",
+        name: "constraint",
         x,
         y,
         type: "csp:constraint",

--- a/js/src/csp/components/CSPBuilder.vue
+++ b/js/src/csp/components/CSPBuilder.vue
@@ -129,7 +129,7 @@ export default class CSPGraphBuilder extends Vue {
     } else if (this.mode === "constraint") {
       this.graph.addNode({
         id: shortid.generate(),
-        name: "constraint",
+        name: "Constraint",
         x,
         y,
         type: "csp:constraint",


### PR DESCRIPTION
1. Now the python code is being printed, I am not able to find documentations for creating a new code block. 
2. The default name of the Variable in cspBuilder is now called "Variable".