### PR TITLE
Bug fixing towards bayes notebook

### DIFF
--- a/js/src/bayes/components/BayesVisualizer.vue
+++ b/js/src/bayes/components/BayesVisualizer.vue
@@ -184,13 +184,26 @@
               if (node.observed !== undefined) {
                   text += "Observation: " + node.observed + '\n';
               }
-              text += "_".repeat(30) + '\n';
-              var prob = "|";
-              var width = 20;
+              var prob = "|"; //symbol simulates probability
+              var probWidth = 10; //default width showing probability symbol (including spaces)
+              var textWidth = 10; // default width showing text of node domain (including spaces)
+
+              //Based on the node name and exact probability number, extend the displaying width
               for (var key in node.prob) {
-                  var number = node.prob[key];
-                  var namel  = key.length;
-                  text += key + " ".repeat(width - 10 - namel) + number.toFixed(this.decimalPlace) + ":" + " ".repeat(5) + prob.repeat(number*20) + " ".repeat(width-number*20) + '\n';
+                  textWidth = Math.max(textWidth, key.length + 2); //reserving 2 spaces as padding
+                  probWidth = Math.max(probWidth, Math.floor(node.prob[key] * 20) + 2) //reserving 2 spaces as padding
+              }
+
+              //Adding underlines to seperate node name and node domain
+              text += "_".repeat(textWidth + probWidth + 4) + '\n';
+
+              //Adding text simulates probability graph 
+              for (var key in node.prob) {
+                  var number = node.prob[key]; //probability number
+                  var namel  = key.length; //length of node domain 
+                  
+                  //displaying line as "domain: prob", inserting spaces to keep format consistent 
+                  text += key + " ".repeat(Math.max(textWidth - namel,0)) + number.toFixed(this.decimalPlace) + ":" + " " + prob.repeat(Math.floor(number*20)) + " ".repeat(probWidth-Math.floor(number * 20)) + '\n';
               }
               return text;
           }

--- a/js/src/components/RectangleGraphNode.vue
+++ b/js/src/components/RectangleGraphNode.vue
@@ -245,7 +245,7 @@
     measureTextWidth(text: string) {
       let canvas = document.createElement('canvas');
       let context = canvas.getContext("2d");
-      context!.font = this.textSize.toString() + "px serif";
+      context!.font = this.textSize.toString() + "px Courier";
       if (text) {
       var splitText : string[] = text.split('\n');
       var measureText : string = splitText[0];

--- a/js/src/components/RoundedRectangleGraphNode.vue
+++ b/js/src/components/RoundedRectangleGraphNode.vue
@@ -4,10 +4,10 @@
           :x="-size.width/2" :y="-size.height/2"
           :fill="fill" :stroke="stroke" :stroke-width="strokeWidth" :rx="this.showFullTextFlag() ? 30 : 25"></rect>
 
-    <text id="text" :font-size="textSize" ref="text" x="0" :y="subtext != null ? (subtext.length != 0 ? -size.height/2 + textSize : 0) : 0" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
+    <text id="text" font-family="Courier" :font-size="textSize" ref="text" x="0" :y="subtext != null ? (subtext.length != 0 ? -size.height/2 + textSize : 0) : 0" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
       {{displayText}}
     </text>
-    <text :v-show="subtext !== undefined" id="subtext" :font-size="textSize - 2"  v-if="subtext != null" ref="subtext" x="0" :y="-size.height/2 + textSize + 2" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
+    <text :v-show="subtext !== undefined" id="subtext" font-family="Courier" :font-size="textSize - 2"  v-if="subtext != null" ref="subtext" x="0" :y="-size.height/2 + textSize + 2" :fill="textColour" text-anchor="middle" alignment-baseline="middle">
       <tspan x="0" dy="1.6em" id="subspan" v-for = "key in displayTest" style="white-space: pre; font-weight: bold;">{{key}}</tspan>
     </text>
   </g>


### PR DESCRIPTION
Fixed bug in Bayes notebook
1: when the length of a node domain is too long, the notebook will freeze when you query the node
2: changed default font to "Courier", a free monospaced font, in this way we can make the format the graph consistent. (i.e. all lines can align perfectly, no worries about the different width of each character)
3: improve the Bayes graph. Auto-adjusting the underlines separating node name and domain, width of the probability, the width of the displaying node domain and spaces inserted within.